### PR TITLE
Split rubocop into its own GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,6 @@ jobs:
         run: |
           yarn install --pure-lockfile
 
-      - name: Run linting
-        run: |
-          bundle exec rubocop --format github
-
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,6 +53,4 @@ jobs:
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
           use_sticky_comment: true # Just update the same comment on each new commit in a PR instead of making a new one
-          sticky_comment: true # Docs are unclear about which of these var names is current as of v1, let's try both
-          continue-on-error: true # Make this job non-fatal - failed reviews won't block merges
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,34 @@
+name: "RuboCop Linting"
+
+on: push
+
+jobs:
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Cache Gems
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install Gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Run RuboCop
+        run: |
+          bundle exec rubocop --format github


### PR DESCRIPTION
tests are essential, rubocop is tbd

- **Remove two invalid keys**
- **Split rubocop into its own GitHub action**
