### PR TITLE
Drop jQuery for vanilla JS and rails-ujs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'propshaft'
 gem 'bootsnap', require: false
 
 # Frontend
-gem 'jquery-rails'
 gem 'haml'
 
 # Auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,10 +132,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jquery-rails (4.6.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.21.2)
     kt-paperclip (8.0.0)
       activemodel (>= 4.2.0)
@@ -365,7 +361,6 @@ DEPENDENCIES
   factory_bot
   haml
   invisible_captcha
-  jquery-rails
   kt-paperclip
   lograge
   mysql2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,38 +4,37 @@
 * (cc) Free Art & Technology Lab
 */
 
-$(document).ready(function(){
+function selectTab(link) {
+  document.querySelectorAll('div.tabs ul.tab_navigation a.selected').forEach(function (selected) {
+    selected.classList.remove('selected');
+  });
+  link.classList.add('selected');
 
-  // Flashes
-  $('#flash-error, #flash-notice, #flash-warning').slideToggle('slow');
-  setTimeout(function(){
-    $('#flash-error, #flash-notice, #flash-warning').slideToggle('slow');
+  var target = document.querySelector(link.getAttribute('href'));
+  if (!target) return;
+  window.scrollTo({ top: target.getBoundingClientRect().top + window.scrollY - 100, behavior: 'smooth' });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Flashes are display:none in CSS -- show them, then take them away again
+  var flashes = document.querySelectorAll('#flash-error, #flash-notice, #flash-warning');
+  flashes.forEach(function (flash) { flash.style.display = 'block'; });
+  setTimeout(function () {
+    flashes.forEach(function (flash) { flash.style.display = 'none'; });
   }, 2500);
 
-  // Zebrafy table rows
-  $("tr:even").css("background-color", "#000");
-  $("tr:odd").css("background-color", "#111");
-
   // Formerly tabs - now a slider control
-  var tabContainers = $('div.tabs > div');
-  $('div.tabs ul.tab_navigation a').click(function (){
-    $('div.tabs ul.tab_navigation a.selected').removeClass('selected');
-    $(this).addClass('selected');
-
-    var target = $(this).attr('href');
-    console.log(target);
-    var top = $(target).offset().top-100;
-		$('html, body').animate({scrollTop:top}, 500);;
-		return false;
+  var tabLinks = document.querySelectorAll('div.tabs ul.tab_navigation a');
+  tabLinks.forEach(function (link) {
+    link.addEventListener('click', function (event) {
+      event.preventDefault();
+      selectTab(link);
+    });
   });
 
   // Select ghettotab based on URL anchor; e.g. #vanderplayer
-  // This can be quirky due to the anchor name = element name
-  // See: http://stackoverflow.com/questions/1384500/activate-url-anchor-but-dont-scroll-to-it
-  $('div.tabs ul.tab_navigation li a').each(function(){
-    var pattern = $(this).attr('href');
-    if(window.location.href.match(pattern)) { $(this).click(); }
-    scroll(0,0); // Re-center the page
+  var fromAnchor = Array.from(tabLinks).find(function (link) {
+    return window.location.href.includes(link.getAttribute('href'));
   });
-
+  if (fromAnchor) selectTab(fromAnchor);
 });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,9 +2,6 @@
 * #000000book stylesheet
 * Jamie Wilkinson <http://jamiedubs.com>
 * (cc) Free Art & Technology Lab
-*
-*= require_tree .
-*= require_self
 */
 
 
@@ -59,7 +56,8 @@ hr {
 }
 
 table { border-collapse: collapse; border-spacing: 0; }
-table tr { }
+table tr:nth-child(odd)  { background-color: #000; }
+table tr:nth-child(even) { background-color: #111; }
 table th { font-family: serif; font-size: 1.2em; background-color: #333; padding: 5px; font-weight: bold; }
 table td { padding: 5px 5px; font-size: 0.9em; }
 

--- a/app/views/favorites/index.html.haml
+++ b/app/views/favorites/index.html.haml
@@ -15,6 +15,6 @@
 
     %td= link_to 'Show', favorite_path(favorite)
     %td= link_to 'Edit', edit_favorite_path(favorite)
-    %td= link_to 'Destroy', favorite_path(favorite), confirm: 'Are you sure?', method: :delete
+    %td= link_to 'Destroy', favorite_path(favorite), method: :delete, data: { confirm: 'Are you sure?' }
 
 = link_to 'New favorite', new_favorite_path

--- a/app/views/layouts/_template_header.html.haml
+++ b/app/views/layouts/_template_header.html.haml
@@ -8,8 +8,8 @@
 
   = stylesheet_link_tag 'application', media: 'all'
   -# Propshaft doesn't read sprockets `//= require` directives, so each file is listed here.
-  -# `jquery` is still 1.12.4 and carries four known XSS advisories; `jquery3` is the maintained one.
-  = javascript_include_tag 'jquery3', 'jquery_ujs', 'application'
+  -# `rails-ujs` ships with actionview and drives data-method/data-confirm on links.
+  = javascript_include_tag 'rails-ujs', 'application'
   = csrf_meta_tags
 
   = yield :head

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -50,7 +50,7 @@
     .gml
       %span.download= link_to('download GML', tag_path(@tag, format: :gml), class: 'button smallbutton')
       %span.what-is-gml= link_to('?', 'http://fffff.at/gml-week-graffiti-markup-language/', target: '_blank')
-      %textarea.gml{cols: 24, rows: 12, onclick: '$(this).select();'}= @tag.gml
+      %textarea.gml{cols: 24, rows: 12, onclick: 'this.select();'}= @tag.gml
 
   -# Tag modbox -- edit/delete/debugging etc.
   - if is_owner?(@tag) || is_admin?
@@ -65,7 +65,7 @@
           %p{style: 'overflow: hidden;'}
             %strong= field
             %br
-            %input{type: 'text', readonly: 'readonly', value: @tag.attributes[field], onclick: '$(this).select();'}
+            %input{type: 'text', readonly: 'readonly', value: @tag.attributes[field], onclick: 'this.select();'}
       %p
         %strong{style: 'color: #f0f'} Parsed GML Header
         - @tag.gml_header.each do |k,v|

--- a/app/views/visualizations/_form.html.haml
+++ b/app/views/visualizations/_form.html.haml
@@ -33,7 +33,7 @@
 
   %p.embed_toggle
     .left= f.check_box :is_embeddable, id: 'embeddable_toggle'
-    %label{for: 'visualization_is_embeddable', style: 'margin-left: 1em', onclick: "$('#embeddable_toggle').click();"}== Embeddable?
+    %label{for: 'embeddable_toggle', style: 'margin-left: 1em'}== Embeddable?
   .embed_details{class: @visualization.is_embeddable ? '' : 'disabled'}
     %label{for: "visualization_embed_url"}== #{required.html_safe} URL to .swf, .js, etc
     = f.text_field :embed_url
@@ -54,18 +54,17 @@
 
 
 :javascript
-  $(document).ready(function(){
-    $('#embeddable_toggle').click(function(){
-      var deets = $('.embed_details');
-      // $(this).is(':checked')
-      deets.find(':input').attr('disabled', !$(this).is(':checked'));
-      if(deets.hasClass('disabled')){
-        deets.removeClass('disabled');
-        deets.find(':input').attr('disabled', false);
-      }
-      else {
-        deets.addClass('disabled');
-        deets.find(':input').attr('disabled', true);
-      }
-    });
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('embeddable_toggle');
+    var details = document.querySelector('.embed_details');
+
+    function syncEmbedDetails() {
+      details.classList.toggle('disabled', !toggle.checked);
+      details.querySelectorAll('input, textarea, select').forEach(function (field) {
+        field.disabled = !toggle.checked;
+      });
+    }
+
+    toggle.addEventListener('change', syncEmbedDetails);
+    syncEmbedDetails();
   });

--- a/app/views/visualizations/index.html.haml
+++ b/app/views/visualizations/index.html.haml
@@ -39,12 +39,12 @@
         %td.admin= app.approved? ? 'Approved' : 'Pending'
         %td.admin.controls
           - if app.approved?
-            = link_to 'unapprove', unapprove_visualization_path(app), method: :put, confirm: 'Are you sure?'
+            = link_to 'unapprove', unapprove_visualization_path(app), method: :put, data: { confirm: 'Are you sure?' }
           - else
-            = link_to 'approve', approve_visualization_path(app), method: :put, confirm: 'Are you sure?'
+            = link_to 'approve', approve_visualization_path(app), method: :put, data: { confirm: 'Are you sure?' }
           %br
           = link_to 'edit', edit_visualization_path(app)
-          = link_to 'delete', visualization_path(app), method: :delete, confirm: "Are you sure?", class: 'delete'
+          = link_to 'delete', visualization_path(app), method: :delete, class: 'delete', data: { confirm: "Are you sure?" }
 
 %p= pagination(@visualizations)
 

--- a/app/views/visualizations/show.html.haml
+++ b/app/views/visualizations/show.html.haml
@@ -45,7 +45,7 @@
     %p.controls
       = link_to 'Edit', edit_visualization_path
       |
-      = link_to 'Delete', visualization_path, confirm: 'Are you sure?', method: :delete
+      = link_to 'Delete', visualization_path, method: :delete, data: { confirm: 'Are you sure?' }
 
   - if is_admin?
     %p
@@ -54,7 +54,7 @@
         = link_to @visualization.approver.login, user_path(@visualization.approver)
         @
         = @visualization.approved_at
-        = link_to 'Unapprove', unapprove_visualization_path, confirm: 'Are you sure?', method: :put
+        = link_to 'Unapprove', unapprove_visualization_path, method: :put, data: { confirm: 'Are you sure?' }
       - else
         Unapproved.
         = link_to 'Approve', approve_visualization_path, method: :put


### PR DESCRIPTION
Closes #123. The site's JavaScript was ~40 lines wrapped in jQuery plus `jquery_ujs`; both are gone, replaced by `querySelectorAll` and the `rails-ujs` that already ships with actionview. Drops the `jquery-rails` gem.

- `confirm: 'Are you sure?'` was Rails 4 syntax and has been silently dropped since Rails 5, so the delete and approve links have had no confirmation dialog. Now `data: { confirm: ... }`.
- the Embeddable? label pointed `for` at an id the checkbox no longer had, which is why it needed an `onclick` to click the box by hand
- zebra striping moved from JS to `tr:nth-child`
- removed the `*= require_tree` sprockets directives, same dead syntax as the `//= require` ones in #126

Verified over HTTP (rails-ujs served, no jQuery in the page, `data-method`/`data-confirm` present) but not with a click-through, so the tab control and flash auto-hide are worth eyeballing.
