### PR TITLE
Remove the fake :xhr MIME type and the render override

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   # protect_from_forgery
 
   # before_action :activate_authlogic
-  before_action :set_format
 
   rescue_from NoPermissionError, with: :permission_denied
 
@@ -133,26 +132,6 @@ class ApplicationController < ActionController::Base
       redirect_to(session[:return_to], opts)
       session[:return_to] = nil
     end
-  end
-
-  # Set XHR as a totally differnet response format than HTML
-  # We don't want to override .js, we use that for actual javascript
-  # FIXME probably no longer applies
-  def set_format
-    # @template.template_format = 'html'
-    request.format = :xhr if request.xhr?
-  end
-
-  # Render XHR without :layout by default
-  def render(*args)
-    if request.xhr?
-      if args.blank?
-        return super(layout: false)
-      elsif args.first.is_a?(Hash) && args.first[:layout].blank?
-        args.first[:layout] = false
-      end
-    end
-    super
   end
 
   # Request params stripped of internal route info

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -197,20 +197,16 @@ class TagsController < ApplicationController
     set_page_title "GML Syntax Validator"
     @noindex = true if @tag.gml.present?
 
+    # Rails resolves a format-less XHR to :js; these callers want the plain-text report
+    request.format = :text if request.xhr? && params[:format].blank?
+
     respond_to do |wants|
-      wants.html do
-        if request.xhr?
-          render plain: @tag.validation_results.inspect
-        else
-          render 'validator'
-        end
-      end
+      wants.html { render 'validator' }
       # FIXME: to_xml does the fuckin' <hash> thing :(
       joined_hash = @tag.validation_results.transform_values { |v| v.join(";\n") }
       wants.xml   { render xml: joined_hash.to_xml(dasherize: false, skip_types: true) }
       wants.json  { render json: @tag.validation_results.to_json(callback: params[:callback]) }
-      wants.xhr   { render plain: @tag.validation_results.map { |k, v| "#{k}=#{v.join(',') || 'none'}" }.join("\n") }
-      wants.text  { render plain: @tag.validation_results.map { |k, v| "#{k}=#{v.join(',') || 'none'}" }.join("\n") }
+      wants.text  { render plain: validation_results_text }
     end
   end
 
@@ -339,6 +335,10 @@ class TagsController < ApplicationController
 
   def tag_parameters
     params.expect(tag: TAG_ATTRIBUTES)
+  end
+
+  def validation_results_text
+    @tag.validation_results.map { |k, v| "#{k}=#{v.join(',') || 'none'}" }.join("\n")
   end
 
   # The validator accepts a bare ?gml= with no :tag key at all

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -6,7 +6,3 @@
 # Graffiti Markup Language (.gml)
 # Mime::Type.register "application/xml", :gml
 Mime::Type.register_alias "application/xml", :gml
-
-# Treat XHRs as a separate format from straight-up HTML
-# TODO FIXME
-Mime::Type.register_alias "text/html", :xhr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     member do
       post :thumbnail
       put :thumbnail
+      get :validate
     end
   end
   post '/tags' => 'tags#create' # backwards-compatibility


### PR DESCRIPTION
Closes #124. A format-less XHR resolves to `:js` in Rails, which is the whole reason for `Mime::Type.register_alias "text/html", :xhr`, a global `set_format` before_action, and an `ApplicationController#render` override. One line in `validate` maps those requests to the real `:text` format instead, and all three go.

- `/validator` was returning a 500 -- the page links to `validate_tag_url` for its own documented API examples and that route didn't exist. Added it as a member route, so `/data/:id/validate.xml` works as advertised.
- the `wants.xhr` and `wants.text` branches rendered identical output; now one `validation_results_text` helper

The XHR contract is covered by an existing spec (`should return text via XMLHttpRequest`) and still passes, so the plain-text response for XHR callers is unchanged.
